### PR TITLE
bpf_sys aarch64

### DIFF
--- a/bpf-sys/build.rs
+++ b/bpf-sys/build.rs
@@ -9,10 +9,19 @@
 use std::env;
 use std::path::PathBuf;
 
-const KERNEL_HEADERS: [&str; 6] = [
+const KERNEL_HEADERS_X86: [&str; 6] = [
     "arch/x86/include/generated/uapi",
     "arch/x86/include/uapi",
     "arch/x86/include/",
+    "include/generated/uapi",
+    "include/uapi",
+    "include",
+];
+
+const KERNEL_HEADERS_AARCH: [&str; 6] = [
+    "arch/arm64/include/generated/uapi",
+    "arch/arm64/include/uapi",
+    "arch/arm64/include/",
     "include/generated/uapi",
     "include/uapi",
     "include",
@@ -61,9 +70,15 @@ fn main() {
         .include("bcc")
         .include("libelf")
         .include(".");
+
     if target.contains("musl") {
+        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+        let kernel_headers = match target_arch.as_str() {
+            "aarch64" => &KERNEL_HEADERS_AARCH,
+            _ => &KERNEL_HEADERS_X86,
+        };
         for include in
-            headers::prefix_kernel_headers(&KERNEL_HEADERS).expect("couldn't find kernel headers")
+            headers::prefix_kernel_headers(kernel_headers).expect("couldn't find kernel headers")
         {
             libbpf.include(include);
         }

--- a/bpf-sys/build.rs
+++ b/bpf-sys/build.rs
@@ -70,7 +70,6 @@ fn main() {
         .include("bcc")
         .include("libelf")
         .include(".");
-
     if target.contains("musl") {
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
         let kernel_headers = match target_arch.as_str() {


### PR DESCRIPTION
While cross compiling for aarch64, bpf_sys was being built with x86 headers and used x86 system call numbers. This change makes sure the correct headers are included when building for aarch64