### PR TITLE
Support BPF_MAP_TYPE_ARRAY read and write

### DIFF
--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -859,7 +859,7 @@ impl<'base, T: Clone> ArrayMap<'base, T> {
             let ret = bpf_sys::bpf_lookup_elem(
                 self.base.fd,
                 &mut idx as *mut _ as *mut _,
-                &mut buf as *mut u8 as *mut _,
+                &mut buf as *mut _ as *mut _,
             );
             if ret < 0 {
                 return Err(Error::BPF)
@@ -888,7 +888,7 @@ impl<'base, T: Clone> ArrayMap<'base, T> {
             let ret = bpf_sys::bpf_update_elem(
                 self.base.fd,
                 &mut idx as *mut _ as *mut _,
-                &mut val as *mut u8 as *mut _,
+                &mut val as *mut _ as *mut _,
                 0,
             );
             if ret < 0 {

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -827,7 +827,7 @@ impl<'base, T: Clone> ArrayMap<'base, T> {
     /// # Example
     /// ```no_run
     /// use redbpf::ArrayMap;
-    /// let ar_map = ArrayMap::new(map)
+    /// let ar_map = ArrayMap::<u32>::new(map)
     ///     .expect("Map given was incorrect type");
     /// ```
     pub fn new(map: &Map) -> Result<ArrayMap<T>> {
@@ -848,7 +848,7 @@ impl<'base, T: Clone> ArrayMap<'base, T> {
     /// # Example
     /// ```no_run
     /// use redbpf::ArrayMap;
-    /// let ar_map = ArrayMap::new(map).unwrap();
+    /// let ar_map = ArrayMap::<u32>::new(map).unwrap();
     /// let value = ar_map.read(10).expect("Could not read from array");
     /// println!("value: {:?}", value);
     /// ```
@@ -877,8 +877,8 @@ impl<'base, T: Clone> ArrayMap<'base, T> {
     /// # Example
     /// ```no_run
     /// use redbpf::ArrayMap;
-    /// let ar_map = ArrayMap::new(map).unwrap();
-    /// match ar_map.write(10, &[0xDE, 0xAD, 0xBE, 0xEF]) {
+    /// let ar_map = ArrayMap::<u32>::new(map).unwrap();
+    /// match ar_map.write(10, 0xDEADBEEF) {
     ///     Ok(()) => println!("Wrote 0xDEADBEEF to array."),
     ///     Err(e) => println!("Couldn't write value: {:?}", e)
     /// };

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -831,7 +831,7 @@ impl ArrayMap<'_> {
     /// ```
     pub fn new(map: &Map) -> Result<ArrayMap<'_>> {
         if map.kind != bpf_sys::bpf_map_type_BPF_MAP_TYPE_ARRAY {
-            return Err(Error::Map)
+            return Err(Error::Map);
         }
 
         Ok(ArrayMap { base: map })

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -834,7 +834,7 @@ impl<'base, T: Clone> ArrayMap<'base, T> {
         if map.kind != bpf_sys::bpf_map_type_BPF_MAP_TYPE_ARRAY {
             return Err(Error::Map);
         }
-        if mem::size_of::<T>() != map.config.key_size as usize {
+        if mem::size_of::<T>() != map.config.value_size as usize {
             return Err(Error::Map);
         }
         Ok(ArrayMap { base: map, _t: PhantomData })
@@ -884,9 +884,6 @@ impl<'base, T: Clone> ArrayMap<'base, T> {
     /// };
     /// ```
     pub fn write(&self, mut idx: u32, mut val: T) -> Result<()> {
-        if val.len() != self.base.config.value_size as usize {
-            return Err(Error::Map);
-        }
         unsafe {
             let ret = bpf_sys::bpf_update_elem(
                 self.base.fd,

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -820,17 +820,17 @@ impl RelocationInfo {
     }
 }
 
-impl ArrayMap<'_, T> {
+impl<'base, T: Clone> ArrayMap<'base, T> {
     /// Create a new ArrayMap from an existing Map. Will return an error if the given
     /// map type is not `BPF_MAP_TYPE_ARRAY`.
     ///
     /// # Example
     /// ```no_run
     /// use redbpf::ArrayMap;
-    /// let ar_map = ArrayMap::<i64>::new(map)
+    /// let ar_map = ArrayMap::new(map)
     ///     .expect("Map given was incorrect type");
     /// ```
-    pub fn new(map: &Map) -> Result<ArrayMap<'_, T>> {
+    pub fn new(map: &Map) -> Result<ArrayMap<T>> {
         if map.kind != bpf_sys::bpf_map_type_BPF_MAP_TYPE_ARRAY {
             return Err(Error::Map);
         }

--- a/redbpf/src/lib.rs
+++ b/redbpf/src/lib.rs
@@ -167,6 +167,9 @@ pub struct StackTrace<'a> {
 
 /// `BPF_MAP_TYPE_ARRAY`, a simple array type that supports reading
 /// and writing by index.
+///
+/// Note: The `mem::size_of::<T>()` **must** match the `.value_size`
+/// set for the array in the eBPF object.
 pub struct ArrayMap<'a, T: Clone> {
     base: &'a Map,
     _t: PhantomData<T>,


### PR DESCRIPTION
Adds support for creating, reading, and writing a map of type `BPF_MAP_TYPE_ARRAY`. See documentation for examples.